### PR TITLE
Add explicit Distillery stubs for each step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3
+* Bug Fixes
+  * Add explicit functions for each of the Distillery Plugin behaviour callbacks.
+
 ## v0.1.2
 * Bug Fixes
   * Only look in `:code.lib_dir()` for the Application lib dir instead of involving `mix`

--- a/lib/bootloader.ex
+++ b/lib/bootloader.ex
@@ -31,9 +31,25 @@ defmodule Bootloader do
   def boot(_), do: []
 
   # Distillery Behaviour
+  def before_assembly(%Release{} = release, _opts) do
+    release
+  end
+
   def after_assembly(%Release{} = release, _opts) do
     generate_boot_script(release)
     release
+  end
+
+  def before_package(%Release{} = release, _opts) do
+    release
+  end
+
+  def after_package(%Release{} = release, _opts) do
+    release
+  end
+
+  def after_cleanup(_args, _opts) do
+    :noop
   end
 
   def generate_boot_script(app_release) do

--- a/lib/bootloader/plugin.ex
+++ b/lib/bootloader/plugin.ex
@@ -1,5 +1,9 @@
 defmodule Bootloader.Plugin do
   use Mix.Releases.Plugin
-  
-  defdelegate after_assembly(_release, _opts), to: Bootloader
+
+  defdelegate before_assembly(release, opts), to: Bootloader
+  defdelegate after_assembly(release, opts), to: Bootloader
+  defdelegate before_package(release, opts), to: Bootloader
+  defdelegate after_package(release, opts), to: Bootloader
+  defdelegate after_cleanup(release, opts), to: Bootloader
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Bootloader.Mixfile do
 
   def project do
     [app: :bootloader,
-     version: "0.1.2",
+     version: "0.1.3",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
This is causing `mix firmware` to fail with an error like the following with recent versions of Distillery:

```bash
|nerves_bootstrap| Building OTP Release...

==> Cleaning all releases..
==> Clean successful!
==> Plugin failed: function Nerves.before_assembly/1 is undefined or private
```